### PR TITLE
Switch to open source buildpack

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -9,6 +9,6 @@ applications:
   instances: 1
   name: speech-to-text-code-pattern
   buildpacks:
-  - sdk-for-nodejs
+  - nodejs-buildpack
   services:
   - sttcp-speech-to-text

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "extends": "react-app"
   },
   "engines": {
-    "node": "14.15.4"
+    "node": ">=14.15.4"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
`sdk-for-nodejs` is being deprecated: https://www.ibm.com/cloud/blog/announcements/ibm-cloud-foundry-nodejs-buildpack-change