### PR TITLE
Promote to master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM base as build
 COPY ./package*.js* /opt/app-root/src/
 RUN npm set progress=false && \
   npm config set depth 0 && \
-  npm install
+  npm ci --only-production --ignore-scripts
 
 COPY ./config /opt/app-root/src/config
 COPY ./public /opt/app-root/src/public

--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
   },
   "lint-staged": {
     "./**/*.{js,scss,html,png,yaml,yml}": [
-      "npm run build",
-      "git add build/*"
+      "npm run build"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
Disable Husky in CI to prevent helm from failing on containerize (#86)

* Change initial npm install to ci to prevent husky

Husky causes containerize to fail from trying to install husky with new base nodejs image

* Remove git add from lint-staged

See https://github.com/okonet/lint-staged/issues/775